### PR TITLE
Add support for other webserver then Apache

### DIFF
--- a/Geary.php
+++ b/Geary.php
@@ -12,6 +12,22 @@
 * @link     https://github.com/mariodian/geary
 */
 
+if (!function_exists('getallheaders'))  {
+    function getallheaders() {
+        if (!is_array($_SERVER)) {
+            return array();
+        }
+
+        $headers = array();
+        foreach ($_SERVER as $name => $value) {
+            if (substr($name, 0, 5) == 'HTTP_') {
+                $headers[str_replace(' ', '-', ucwords(strtolower(str_replace('_', ' ', substr($name, 5)))))] = $value;
+            }
+        }
+        return $headers;
+    }
+}
+
 class Geary {
     const CONNECT_TIMEOUT = 60;
     const API_URL = 'https://gateway.gear.mycelium.com';


### PR DESCRIPTION
getallheaders() function only exists on apache servers. This is the fix.